### PR TITLE
Agregar archivo .gitignore para ignorar archivos y carpetas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignorar todos los archivos .log de cualquier directorio
+*.log
+
+# Ignorar todos los archivos compilados por python
+__pycache__/
+*.pyc


### PR DESCRIPTION
Se añade el archivo .gitignore para evitar que se suban al repositorio archivos innecesarios como:

- Carpetas __pycache__ y archivos .pyc generados por Python.
- Archivos de log (*.log).